### PR TITLE
Fix TTL handling in Chat model

### DIFF
--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -7,5 +7,11 @@ class Chat(Document):
     messages = ListField(DictField(), default=[])
     created_at = DateTimeField(default=datetime.utcnow)
     updated_at = DateTimeField(default=datetime.utcnow)
+    ttl = DateTimeField(default=datetime.utcnow)
 
-    meta = {'collection': 'chats'} 
+    meta = {
+        'collection': 'chats',
+        'indexes': [
+            {'fields': ['ttl'], 'expireAfterSeconds': 0}
+        ]
+    }


### PR DESCRIPTION
## Summary
- add a `ttl` field to the Chat document
- create a TTL index so chats can expire

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bd7f36450832594368a56f59e4e50