### PR TITLE
Add AWS Lambda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,30 @@ Standard HTTP status codes are used:
 - 429: Too Many Requests (quota exceeded)
 - 500: Internal Server Error
 
+## Serverless Deployment with AWS CLI
+
+This repository includes a `template.yaml` CloudFormation template to
+deploy the application as an AWS Lambda function behind API Gateway.
+
+1. **Package the application**
+   ```bash
+   aws cloudformation package \
+       --template-file template.yaml \
+       --s3-bucket <your-deployment-bucket> \
+       --output-template-file packaged.yaml
+   ```
+
+2. **Deploy the stack**
+   ```bash
+   aws cloudformation deploy \
+       --template-file packaged.yaml \
+       --stack-name aichat-api \
+       --capabilities CAPABILITY_IAM
+   ```
+
+The deployment output includes the API Gateway URL that serves the
+Flask application via Lambda.
+
 ## Contributing
 
 1. Fork the repository

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,9 @@
+import awsgi
+from app import create_app
+
+app = create_app()
+
+
+def lambda_handler(event, context):
+    """AWS Lambda entry point for the Flask application."""
+    return awsgi.response(app, event, context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,3 +104,4 @@ xxhash==3.5.0
 yarl==1.20.0
 zipp==3.21.0
 zstandard==0.23.0
+awsgi==2.2.0

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless stack for the AI Chat API
+
+Globals:
+  Function:
+    Runtime: python3.11
+    Timeout: 30
+    MemorySize: 512
+    Handler: lambda_function.lambda_handler
+
+Resources:
+  ApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Policies: AWSLambdaBasicExecutionRole
+      Events:
+        ApiEvent:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /{proxy+}
+            Method: ANY
+
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: prod
+
+Outputs:
+  ApiUrl:
+    Description: 'URL of the deployed API'
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/prod/'


### PR DESCRIPTION
## Summary
- add `awsgi` to requirements
- provide `lambda_function.py` entrypoint for AWS Lambda
- create `template.yaml` CloudFormation template
- document packaging and deployment in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd96d30c083258235e946a6e82ff2